### PR TITLE
Make DocumentDB calls async

### DIFF
--- a/DocumentDbRepositories/Implementation/DocumentQueryExtensions.cs
+++ b/DocumentDbRepositories/Implementation/DocumentQueryExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Azure.Documents.Linq;
+
+namespace DocumentDbRepositories.Implementation
+{
+    public static class DocumentQueryExtensions
+    {
+        public static async Task<List<T>> ToListAsync<T>(this IDocumentQuery<T> query)
+        {
+            List<T> results = new List<T>();
+            while (query.HasMoreResults)
+            {
+                var response = await query.ExecuteNextAsync<T>();
+                results.AddRange(response);
+            }
+            return results;
+        }
+        public static async Task<T> FirstOrDefaultAsync<T>(this IDocumentQuery<T> query)
+        {
+            var response = await query.ExecuteNextAsync<T>();
+            return response.FirstOrDefault();
+        }
+    }
+}

--- a/DocumentDbRepositories/Implementation/ResourceRepository.cs
+++ b/DocumentDbRepositories/Implementation/ResourceRepository.cs
@@ -18,26 +18,24 @@ namespace DocumentDbRepositories.Implementation
 			_client = client;
 			_collection = collection;
 		}
-		public Task<ScampResource> GetResource(string resourceId)
-		{
-			//TODO Check
-			var resources = from r in _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
-							where r.Id == resourceId && r.Type == "resource"
-							select r;
-			var resourceList = resources.ToList();
-			if (resourceList.Count == 0)
-				return Task.FromResult((ScampResource)null);
-			return Task.FromResult(resourceList[0]);
-		}
+        public async Task<ScampResource> GetResource(string resourceId)
+        {
+            //TODO Check
+            var resources = from r in _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
+                            where r.Id == resourceId && r.Type == "resource"
+                            select r;
+            var resource= await resources.AsDocumentQuery().FirstOrDefaultAsync();
+            return resource;
+        }
 
-		public Task<IEnumerable<ScampResourceGroup>> GetResources()
-		{
-			var resources = from r in _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
-							where r.Type == "resource"
-							select r;
-			var resourceList = resources.ToList();
-			return Task.FromResult((IEnumerable<ScampResourceGroup>)resourceList);
-		}
+        public async Task<IEnumerable<ScampResource>> GetResources()
+        {
+            var resources = from r in _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
+                            where r.Type == "resource"
+                            select r;
+            var resourceList = await resources.AsDocumentQuery().ToListAsync();
+            return resourceList;
+        }
 
         // given a list of resourceId's, return the resource references
         public async Task<List<ScampResourceReference>> GetResources(List<string> resourceIds)
@@ -49,46 +47,46 @@ namespace DocumentDbRepositories.Implementation
             return rtnList;
         }
 
-		public Task<IEnumerable<ScampResourceGroup>> GetResourcesByOwner(string userId)
-		{
-			//TODO: need to add "join" to get by owner relationship
-			var resources = from r in _client.CreateDocumentQuery<ScampResourceGroup>(_collection.SelfLink)
-							select r;
-			var resourceList = resources.ToList();
-			return Task.FromResult((IEnumerable<ScampResourceGroup>)resourceList);
-		}
+        public async Task<IEnumerable<ScampResourceGroup>> GetResourcesByOwner(string userId)
+        {
+            //TODO: need to add "join" to get by owner relationship
+            var resources = from r in _client.CreateDocumentQuery<ScampResourceGroup>(_collection.SelfLink)
+                            select r;
+            var resourceList = await resources.AsDocumentQuery().ToListAsync();
+            return resourceList;
+        }
 
-		public async Task CreateResource(ScampResource resource)
+        public async Task CreateResource(ScampResource resource)
 		{
-
 			var created = await _client.CreateDocumentAsync(_collection.SelfLink, resource);
 		}
 
-		public Task<IEnumerable<ScampResource>> GetResourcesByGroup(ScampUserReference user, string groupId)
-		{
-			bool isGroupAdmin = IsGroupAdmin(user, groupId);
+        public async Task<IEnumerable<ScampResource>> GetResourcesByGroup(ScampUserReference user, string groupId)
+        {
+            bool isGroupAdmin = await IsGroupAdminAsync(user, groupId);
 
-			var resources = _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
-				.Where(u => u.Type == "resource" && u.ResourceGroup.Id == groupId);
-			if (!isGroupAdmin)
-			{
-				resources = resources.Where(u => u.Owners[0].Id == user.Id);
-			}
-			var resourceList = resources.ToList();
-			return Task.FromResult((IEnumerable<ScampResource>)resourceList);
-		}
+            var resources = _client.CreateDocumentQuery<ScampResource>(_collection.SelfLink)
+                .Where(u => u.Type == "resource" && u.ResourceGroup.Id == groupId);
+            if (!isGroupAdmin)
+            {
+                resources = resources.Where(u => u.Owners[0].Id == user.Id);
+            }
+            var resourceList = await resources.AsDocumentQuery().ToListAsync();
+            return resourceList;
+        }
 
-		private bool IsGroupAdmin(ScampUserReference user, string groupId)
-		{	// check all group's admin
-			return _client.CreateDocumentQuery<dynamic>(_collection.SelfLink, new SqlQuerySpec
-			{
-				QueryText = "SELECT g FROM Groups g JOIN u IN g.admins WHERE g.id = @groupId AND g.type='group' AND u.id = @userId",
-				Parameters = new SqlParameterCollection()
-					{
-						  new SqlParameter("@groupId", groupId),
-						  new SqlParameter("@userId", user.Id)
-					}
-			}).ToList().Any();
+        private async Task<bool> IsGroupAdminAsync(ScampUserReference user, string groupId)
+		{   // check all group's admin
+            var match = await _client.CreateDocumentQuery<dynamic>(_collection.SelfLink, new SqlQuerySpec
+            {
+                QueryText = "SELECT g FROM Groups g JOIN u IN g.admins WHERE g.id = @groupId AND g.type='group' AND u.id = @userId",
+                Parameters = new SqlParameterCollection()
+                    {
+                          new SqlParameter("@groupId", groupId),
+                          new SqlParameter("@userId", user.Id)
+                    }
+            }).AsDocumentQuery().FirstOrDefaultAsync();
+            return match != null;
 		}
 
 		public Task AddResource(string groupID)
@@ -105,19 +103,22 @@ namespace DocumentDbRepositories.Implementation
 
 		public async Task UpdateResource(ScampResource resource)
 		{
-			//TODO Check
-			var dbRes = (from u in _client.CreateDocumentQuery(_collection.SelfLink)
-						 where u.Id == resource.Id
-						 select u).ToList().FirstOrDefault();
+            //TODO Check
+            var dbRes = await (from u in _client.CreateDocumentQuery(_collection.SelfLink)
+                                     where u.Id == resource.Id
+                                     select u)
+                                     .AsDocumentQuery().FirstOrDefaultAsync();
 
 			await _client.ReplaceDocumentAsync(dbRes.SelfLink, resource);
 		}
 
 		public async Task DeleteResource(string resourceId)
 		{
-			var dbRes = (from u in _client.CreateDocumentQuery(_collection.SelfLink)
-						 where u.Id == resourceId
-						 select u).ToList().FirstOrDefault();
+            var dbRes = await (from u in _client.CreateDocumentQuery(_collection.SelfLink)
+                                     where u.Id == resourceId
+                                     select u)
+                                     .AsDocumentQuery().FirstOrDefaultAsync();
+
 			await _client.DeleteDocumentAsync(dbRes.SelfLink);
 		}
 	}

--- a/DocumentDbRepositories/Implementation/SubscriptionRepository.cs
+++ b/DocumentDbRepositories/Implementation/SubscriptionRepository.cs
@@ -27,26 +27,23 @@ namespace DocumentDbRepositories.Implementation
             var created = await _client.CreateDocumentAsync(_collection.SelfLink, newSubscription);
         }
 
-        public Task<ScampSubscription> GetSubscription(string subscriptionId)
+        public async Task<ScampSubscription> GetSubscription(string subscriptionId)
         {
             var subscriptions = from u in _client.CreateDocumentQuery<ScampSubscription>(_collection.SelfLink)
                                 where u.Id == subscriptionId
                                 select u;
-            var subList = subscriptions.ToList();
-            if (subList.Count == 0)
-                return Task.FromResult((ScampSubscription)null);
-            return Task.FromResult(subList[0]);
-
+            var subscription = await subscriptions.AsDocumentQuery().FirstOrDefaultAsync();
+            return subscription;
         }
 
-        public Task<List<ScampSubscription>> GetSubscriptions()
+        public async Task<List<ScampSubscription>> GetSubscriptions()
         {
             var subscriptions = from u in _client.CreateDocumentQuery<ScampSubscription>(_collection.SelfLink)
                                 select u;
-            var subList = subscriptions.ToList();
+            var subList = await subscriptions.AsDocumentQuery().ToListAsync();
             if (subList.Count == 0)
-                return Task.FromResult((List<ScampSubscription>)null);
-            return Task.FromResult(subList);
+                return null;
+            return subList;
         }
     }
 }

--- a/DocumentDbRepositories/Implementation/SystemSettingsRepository.cs
+++ b/DocumentDbRepositories/Implementation/SystemSettingsRepository.cs
@@ -24,15 +24,15 @@ namespace DocumentDbRepositories.Implementation
         }
 
         // get a list of system administrators
-        public Task<List<ScampUser>> GetSystemAdministrators()
+        public async Task<List<ScampUser>> GetSystemAdministrators()
         {
             var admins = from u in _client.CreateDocumentQuery<ScampUser>(_collection.SelfLink)
                          where u.isSystemAdmin == true
                          select u;
-            var adminList = admins.ToList();
+            var adminList = await admins.AsDocumentQuery().ToListAsync();
             if (adminList.Count == 0)
-                return Task.FromResult((List<ScampUser>)null);
-            return Task.FromResult(adminList);
+                return null;
+            return adminList;
         }
     }
 }

--- a/DocumentDbRepositories/Implementation/UserRepository.cs
+++ b/DocumentDbRepositories/Implementation/UserRepository.cs
@@ -11,7 +11,7 @@ using DocumentDbRepositories;
 
 namespace DocumentDbRepositories.Implementation
 {
-    public class UserRepository 
+    public class UserRepository
     {
         private readonly DocumentClient _client;
         private readonly DocumentCollection _collection;
@@ -26,18 +26,15 @@ namespace DocumentDbRepositories.Implementation
 			var created = await _client.CreateDocumentAsync(_collection.SelfLink, newUser);
 		}
 
-		public Task<ScampUser> GetUserbyId(string userId)
+		public async Task<ScampUser> GetUserbyId(string userId)
         {
             // get specified user by ID
             var queryResult = from u in _client.CreateDocumentQuery<ScampUser>(_collection.SelfLink)
                               where u.Id == userId
                               select u;
-            var user = queryResult.ToList().FirstOrDefault();
+            var user = await queryResult.AsDocumentQuery().FirstOrDefaultAsync();
 
-            if (user == null)
-                return Task.FromResult((ScampUser)null);
-
-            return Task.FromResult((ScampUser)user);
+            return user;
         }
 
         public async Task UpdateUser(ScampUser user)


### PR DESCRIPTION
Since we had the signatures async it seemed crazy not to be making the calls async!
Added a couple of extensions in DocumentQueryExtensions: ToListAsync() and FirstOrDefaultAsync()
These are now used in the calls in the repositories instead of ToList()
Overall, this simplified the code (IMO) and I've parallelised DocumentDB calls in GroupRepository.GetGroupWithResources as the simplification made it more manageable