### PR TITLE
Fix issue #171.

### DIFF
--- a/ScampApi/wwwroot/App/Scripts/app.js
+++ b/ScampApi/wwwroot/App/Scripts/app.js
@@ -3,7 +3,8 @@ angular.module('scamp', ['ngRoute', 'AdalAngular', 'ui.bootstrap'])
 .config(['$routeProvider', '$httpProvider', 'adalAuthenticationServiceProvider', '$locationProvider', function ($routeProvider, $httpProvider, adalProvider, $locationProvider) {
 
     $routeProvider.when("/Home", {
-        controller: "homeCtrl",
+        // Not setting the home controller here, because it is included already
+        // in the HTML content.
         templateUrl: "/App/Views/Home.html",
     }).when("/settings/groupMgr", {
         controller: "GroupManagerController",

--- a/ScampApi/wwwroot/App/Scripts/dashboardCtrl.js
+++ b/ScampApi/wwwroot/App/Scripts/dashboardCtrl.js
@@ -26,44 +26,50 @@ angular.module('scamp')
 	};
 
 	$scope.populate = function () {
+	  var populateDashboard = function () {
 	    scampDashboard.initialize();
-
 	    var userGUID = $scope.userProfile.id;
-        //Default the view to admin view as long as the user has administrative priviledges or keep the view as it is if it's set to admin
-	    if (!$scope.dashboardView && $scope.isAdmin || ($scope.dashboardView && $scope.dashboardView=='admin'))
-	        $scope.dashboardView = 'admin';
+	    //Default the view to admin view as long as the user has administrative priviledges or keep the view as it is if it's set to admin
+	    if (!$scope.dashboardView && $scope.isAdmin || ($scope.dashboardView && $scope.dashboardView == 'admin'))
+	      $scope.dashboardView = 'admin';
 	    else
-	        $scope.dashboardView = 'user';
+	      $scope.dashboardView = 'user';
 
 	    $scope.dashboardStatus = 'loading';
 
-	    userSvc.getGroupList(userGUID, $scope.dashboardView).then(
-            function (data) {
-                if (data && data.length > 0) {
-                    $scope.groups = data.map(function (item) {
-                        return scampDashboard.computeUsagePercentages(item);
-                    });
-                    $scope.selectedGroupId = data[0].id;
-                    $scope.selectedGroupName = data[0].name;
-                    var summaryPanelType = 'usage';
-                    
-                    if ($scope.dashboardView == 'admin') {
-                        $scope.loadUsers($scope.selectedGroupId);
-                        summaryPanelType = 'budget';
-                    } else
-                        $scope.loadResources($scope.selectedGroupId, userGUID);
+	    userSvc.getGroupList(userGUID, $scope.dashboardView)
+      .then(function (data) {
+        if (data && data.length > 0) {
+          $scope.groups = data.map(function (item) {
+            return scampDashboard.computeUsagePercentages(item);
+          });
+          $scope.selectedGroupId = data[0].id;
+          $scope.selectedGroupName = data[0].name;
+          var summaryPanelType = 'usage';
 
-                    $scope.updateSummaryPanel(userGUID, summaryPanelType);
-                    $scope.dashboardStatus = 'loaded';
-                } else
-                    throw new Error("User " + userGUID + " doesnt have permission to any groups for " + $scope.dashboardView + " view");
-            },
-            // resource REST call failed
-            function (statusCode) {
-                console.error(statusCode);
-                $scope.dashboardStatus = 'loaded';
-            }
-        );
+          if ($scope.dashboardView == 'admin') {
+            $scope.loadUsers($scope.selectedGroupId);
+            summaryPanelType = 'budget';
+          } else
+            $scope.loadResources($scope.selectedGroupId, userGUID);
+
+          $scope.updateSummaryPanel(userGUID, summaryPanelType);
+          $scope.dashboardStatus = 'loaded';
+        } else {
+          throw new Error("User " + userGUID + " doesnt have permission to any groups for " + $scope.dashboardView + " view");
+        }
+      })
+      .catch(function (statusCode) {
+        // resource REST call failed
+        console.error(statusCode);
+        $scope.dashboardStatus = 'loaded';
+      });
+	  };
+	  if ($scope.userProfile) {
+	    populateDashboard();
+	  } else {
+	    $scope.$on('userProfileFetched', populateDashboard);
+	  }
 	};
 
 	$scope.loadUsers = function (groupId) {

--- a/ScampApi/wwwroot/App/Scripts/homeCtrl.js
+++ b/ScampApi/wwwroot/App/Scripts/homeCtrl.js
@@ -26,6 +26,7 @@ angular.module('scamp')
             $scope.loadingMessage = "";
             console.log($scope.userProfile);
             $location.path("/dashboard");
+            $scope.$broadcast('userProfileFetched');
             //$window.location.href.path("/dashboard");
         }).error(function (err) {
             console.log("get failed");

--- a/ScampApi/wwwroot/App/Views/Header.html
+++ b/ScampApi/wwwroot/App/Views/Header.html
@@ -70,7 +70,7 @@
                 <li class="dropdown">
                     <a class="dropdown-toggle" style="padding-left: 2px;" data-toggle="dropdown" role="button" aria-expanded="false">{{userProfile.name}}<b class="caret"></b></a>
                     <ul class="dropdown-menu dropdown-menu-header" role="menu">
-                        <li><a href="logout()">Logout</a></li>
+                        <li><a href="" ng-click="logout()">Logout</a></li>
                     </ul>
                 </li>
             </ul>


### PR DESCRIPTION
When the page was reloaded, the dashboard controller tried to access
the user profile before it was returned from the API. This resulted into
a JavaScript error and prevented the rest of the dashboard functionality.

This change adds an event to be broadcasted from homeCtrl.js that is
listened for in case the user profile is not yet fetched.