### PR TITLE
Test setup and an initial E2E test.

### DIFF
--- a/ScampApi/Gruntfile.js
+++ b/ScampApi/Gruntfile.js
@@ -1,0 +1,50 @@
+﻿var path = require('path');
+
+module.exports = function (grunt) {
+    require('load-grunt-tasks')(grunt);
+
+    grunt.initConfig({
+        shell: {
+            restore: {
+                command: 'dnu restore'
+            },
+            build: {
+                command: 'dnu build'
+            },
+            run: {
+                command: 'dnx . web',
+                options: {
+                    async: true
+                }
+            },
+            webdriver_update: {
+                command: path.resolve('node_modules/.bin/webdriver-manager') + ' update'
+            },
+            protractor: {
+                command: path.resolve('node_modules/.bin/protractor') + ' ' + path.join('test/conf.js')
+            }
+        },
+        waitServer: {
+            server: {
+                options: {
+                    url: 'http://localhost:44000',
+                    timeout: 20 * 1000
+                }
+            },
+        },
+        protractor_webdriver: {
+            start: {
+                options: {
+                    // Workaround for a similar issue than what is reported at:
+                    // https://github.com/teerapap/grunt-protractor-runner/issues/111
+                    keepAlive: true
+                }
+            }
+        }
+    });
+
+    grunt.registerTask('build', ['shell:restore', 'shell:build']);
+    grunt.registerTask('run', ['shell:run', 'waitServer']);
+    grunt.registerTask('protractor-e2e-tests', ['shell:webdriver_update', 'protractor_webdriver', 'shell:protractor']);
+    grunt.registerTask('test', ['run', 'protractor-e2e-tests']);
+};

--- a/ScampApi/Startup.cs
+++ b/ScampApi/Startup.cs
@@ -78,7 +78,9 @@ namespace ScampApi
                 options.Authority = String.Format(Configuration.Get("AadInstance"), Configuration.Get("TenantId"));
             });
 
-            //app.UseStaticFiles();
+            // Required by kestrel and web commands.
+            app.UseStaticFiles();
+
             // Add MVC to the request pipeline.
             app.UseMvc(routes =>
             {

--- a/ScampApi/Views/Home/Index.cshtml
+++ b/ScampApi/Views/Home/Index.cshtml
@@ -12,7 +12,7 @@
 
 }
 
-<div ng-app="scamp" ng-controller="homeCtrl" role="document">
+<div id="scamp-ng-app" ng-app="scamp" ng-controller="homeCtrl" role="document">
     <div ng-include="'/App/Views/Header.html'">
         <!--header-->
     </div>

--- a/ScampApi/package.json
+++ b/ScampApi/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "org.simplecloudmgr.scamp",
+  "version": "1.0.0",
+  "description": "",
+  "dependencies": {},
+  "devDependencies": {
+    "grunt": "^0.4.5",
+    "grunt-protractor-webdriver": "^0.2.0",
+    "grunt-shell-spawn": "^0.3.8",
+    "grunt-wait-server": "^0.1.2",
+    "load-grunt-tasks": "^3.2.0",
+    "protractor": "^2.1.0",
+    "webdriver-manager": "^5.2.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  },
+  "author": "",
+  "license": ""
+}

--- a/ScampApi/project.json
+++ b/ScampApi/project.json
@@ -25,7 +25,7 @@
     },
 
   "commands": {
-    "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:5000"
+    "web": "Microsoft.AspNet.Hosting --server Microsoft.AspNet.Server.WebListener --server.urls http://localhost:44000"
   },
 
     "frameworks": {

--- a/ScampApi/test/conf.js
+++ b/ScampApi/test/conf.js
@@ -1,0 +1,5 @@
+exports.config = {
+    seleniumAddress: 'http://localhost:4444/wd/hub',
+    rootElement: '#scamp-ng-app',
+    specs: ['spec.js']
+}

--- a/ScampApi/test/spec.js
+++ b/ScampApi/test/spec.js
@@ -1,0 +1,7 @@
+describe('SCAMP Home Page', function () {
+    it('should have a title', function () {
+        browser.get('http://localhost:44000/');
+
+        expect(browser.getTitle()).toEqual('Scamp');
+    });
+});

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,19 @@
+version: 1.0.{build}
+os: Visual Studio 2015 RC
+environment:
+  DNX_FEED: https://www.nuget.org/api/v2
+  APPSETTING_ClientId:
+    secure: TxO8zwY46T7BnQDX8lEcp1laMl+1Y6YTolmNQuD/KDzi+XQQhOlt4ks4UooL2TP7
+  APPSETTING_TenantId:
+    secure: c2t3nyLB7qHzPdQUkZzeNp9chniaUYsvHHX6kEXChX0=
+install:
+  - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
+  - dnvm install -a default 1.0.0-beta4
+  - set PATH=C:\Users\appveyor\.dnx\runtimes\dnx-clr-win-x86.1.0.0-beta4\bin;%PATH%
+  - cd ScampApi
+  - npm install -g grunt-cli
+  - npm install
+build_script:
+  - grunt build
+test_script:
+  - grunt test


### PR DESCRIPTION
This is a proposal about how end-to-end testing could be wired up and executed in a CI environment.

Here is what roughly happens in the AppVeyor CI:

1. A suitable DNX runtime is installed.
2. Dependencies from npm repository are fetched via `npm install`.
3. A grunt task is used to build the solution (in practice, the project defined in `ScampApi/project.json`).
4. The Scamp Web site is started on localhost and the Grunt runner waits until the server is listening in the known port.
5. Google Chrome is launched in the CI machine and E2E tests written on top of Protractor are executed.

The only test written so far is one that loads the home page and expects the page to have a known title.

An example of a success run can be seen at https://ci.appveyor.com/project/vjrantal/scamp/build/1.0.12.

One thing to highlight is that to connect to the required external services (like an Azure DocumentDB), values like connection strings are needed. Since the values can't be made publicly available, AppVeyor's secure variables are used. This brings a limitation when verifying pull requests, because in that case, secure variables are not available (for security reasons).

Going forward, it could be considered that the CI would run integration tests that have mock ups for certain external services and thus wouldn't need any secured variables. The E2E tests that require external services could be run offline from single-commit / pull-request verifications and thus could rely on secured variables.