### PR TITLE
Fix dashboard view selection bug

### DIFF
--- a/ScampApi/wwwroot/App/Scripts/dashboardCtrl.js
+++ b/ScampApi/wwwroot/App/Scripts/dashboardCtrl.js
@@ -24,20 +24,22 @@ angular.module('scamp')
 	    2: "Web App"
 	};
 
+	$scope.state = {};
+
 	$scope.populate = function () {
 	  var populateDashboard = function () {
 	    scampDashboard.initialize();
 	    var userGUID = $scope.userProfile.id;
 
 	    //Default the view to admin view as long as the user has administrative priviledges or keep the view as it is if it's set to admin
-	    if (!$scope.dashboardView && $scope.userProfile.isSystemAdmin || ($scope.dashboardView && $scope.dashboardView == 'admin'))
-	      $scope.dashboardView = 'admin';
+	    if (!$scope.state.view && $scope.userProfile.isSystemAdmin || ($scope.state.view && $scope.state.view == 'admin'))
+	      $scope.state.view = 'admin';
 	    else
-	      $scope.dashboardView = 'user';
+	      $scope.state.view = 'user';
 
 	    $scope.dashboardStatus = 'loading';
 
-	    userSvc.getGroupList(userGUID, $scope.dashboardView)
+	    userSvc.getGroupList(userGUID, $scope.state.view)
           .then(function (data) {
             if (data && data.length > 0) {
               $scope.groups = data.map(function (item) {
@@ -47,7 +49,7 @@ angular.module('scamp')
               $scope.selectedGroupName = data[0].name;
               var summaryPanelType = 'usage';
 
-              if ($scope.dashboardView == 'admin') {
+              if ($scope.state.view == 'admin') {
                 $scope.loadUsers($scope.selectedGroupId);
                 summaryPanelType = 'budget';
               } else
@@ -56,7 +58,7 @@ angular.module('scamp')
               $scope.updateSummaryPanel(userGUID, summaryPanelType);
               $scope.dashboardStatus = 'loaded';
             } else {
-              throw new Error("User " + userGUID + " doesnt have permission to any groups for " + $scope.dashboardView + " view");
+              throw new Error("User " + userGUID + " doesnt have permission to any groups for " + $scope.state.view + " view");
             }
           })
           .catch(function (statusCode) {
@@ -258,24 +260,7 @@ angular.module('scamp')
 	    $('#resourceSendActionModal').modal('hide');
 	};
 
-}])
-.directive("radioButton", function () {//This is a workaround due to a Bootstrap 3 bug with Angular which doesnt support radio buttons. 
-    return {
-        restrict: 'A',
-        require: 'ngModel',
-        link: function (scope, element, attrs, ctrl) {
-            element.bind('click', function () {
-                if (!element.hasClass('active')) {
-                    scope.$apply(function () {
-                        scope.dashboardView = attrs.value;
-                        scope.populate();
-                    });
-                }
-              }
-            );
-        }
-    }
-});
+}]);
 
 angular.module('scamp')
 .controller('GroupUsersModalCtrl', function ($scope, $modalInstance, groupSvc, group, users, currentUser) {

--- a/ScampApi/wwwroot/App/Views/Dashboard.html
+++ b/ScampApi/wwwroot/App/Views/Dashboard.html
@@ -34,11 +34,11 @@
 <div id="content-header" ng-if="userProfile.isSystemAdmin">
     <h2>Dashboard Insights</h2>
     &nbsp;&nbsp;&nbsp;Select a view:
-    <span class="btn-group" data-toggle="buttons">
-        <label class="btn btn-primary btn-xs" ng-class="(dashboardView=='admin' ? 'active' : '')" radio-button ng-model="dashboardView" value="admin">
+    <span class="btn-group">
+        <label class="btn btn-primary btn-xs" btn-radio="'admin'" ng-model="state.view" ng-change="populate()">
             Admin
         </label>
-        <label class="btn btn-primary btn-xs" ng-class="(dashboardView=='user' ? 'active' : '')" radio-button ng-model="dashboardView" value="user">
+        <label class="btn btn-primary btn-xs" btn-radio="'user'" ng-model="state.view" ng-change="populate()">
             Student
         </label>
     </span>
@@ -60,7 +60,7 @@
                                   </div>
                                   <div class="group-item-status">
                                       <div>{{group.name}}</div>
-                                      <div class="progress" ng-show="dashboardView=='admin'">
+                                      <div class="progress" ng-show="state.view=='admin'">
                                           <div class="progress-bar progress-bar-info" role="progressbar" style="width:{{group.usageLabel}}%">
                                               {{group.usageLabel}}%
                                           </div>
@@ -71,7 +71,7 @@
                                               {{group.unallocatedLabel}}% Unallocated
                                           </div>
                                       </div>
-                                      <div class="progress"  ng-show="dashboardView=='user'">
+                                      <div class="progress"  ng-show="state.view=='user'">
                                           <div class="progress-bar" role="progressbar" aria-valuenow="{{group.usageLabel}}" aria-valuemin="0" aria-valuemax="100" style="min-width: 2em; width: {{group.usageLabel}}%;">
                                               {{group.usageLabel}}%
                                           </div>
@@ -88,10 +88,10 @@
                         </div>
                         <div class="row">
                           <div class="col-md-12">
-                            <div ng-show="dashboardView=='user'" style="display: inline;">
+                            <div ng-show="state.view=='user'" style="display: inline;">
                               Your Resource usage:
                             </div>
-                            <div class="btn-group action-cell" ng-show="dashboardView=='admin'" style="display: inline;">
+                            <div class="btn-group action-cell" ng-show="state.view=='admin'" style="display: inline;">
                               <button class="btn btn-primary btn-sm dropdown-toggle" type="button" data-toggle="dropdown" aria-expanded="false">
                                 <span class="" style="color:#fff;">
                                   <img src="/app/images/default_profile_2_0.jpg" class="img-rounded user-avatar-sm" style="width: 25px;height: 25px;">


### PR DESCRIPTION
We were running into an issue with JavaScript's prototypal inheritance.
`ng-model` can never be used with a primitive variable in scope, it always
has to be an element of an object (i.e. must contain a '.').

For more details and explanation, see
https://github.com/angular/angular.js/wiki/Understanding-Scopes

To completely fix the issue, I dropped the workaround @erikschlegel had implemented (the `radioButton` directive) and replaced with [AngularUI Bootstrap radio buttons](https://angular-ui.github.io/bootstrap/#/buttons) (html radio buttons had been used before the workaround). I did not find any issues in my testing.

Closes #213.