### PR TITLE
"Create Group" api implementation

### DIFF
--- a/DocDbSetup/SP_CreateGroup.js
+++ b/DocDbSetup/SP_CreateGroup.js
@@ -23,6 +23,7 @@ function (groupDoc) {
 
     // add user to group
     function CreateGroup(groupDoc, userDoc) {
+
         // define user for group list
         var groupFrag = {
             "id": userDoc.id,
@@ -34,6 +35,9 @@ function (groupDoc) {
             groupDoc.members = {};
         // add the user to the group collection
         groupDoc.members.push(groupFrag);
+
+        // add user's default allocation to the group's allocated amount
+        groupDoc.budget.allocated += groupDoc.budget.defaultUserAllocation
 
         // increment user's allocated budget amount by group budget amount
         userDoc.budget.allocated += groupDoc.budget.unitsBudgeted;

--- a/DocumentDbRepositories/ScampBudget.cs
+++ b/DocumentDbRepositories/ScampBudget.cs
@@ -13,9 +13,9 @@ namespace DocumentDbRepositories
     public class ScampUserBudget
     {
         [JsonProperty(PropertyName = "unitsBudgeted")]
-        public double unitsBudgeted { get; set; }
+        public long unitsBudgeted { get; set; }
         [JsonProperty(PropertyName = "allocated")]
-        public double Allocated { get; set; }
+        public long Allocated { get; set; }
         [JsonProperty(PropertyName = "enddate")]
         public DateTime EndDate { get; set; }
     }
@@ -27,6 +27,6 @@ namespace DocumentDbRepositories
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }
         [JsonProperty(PropertyName = "defaultUserAllocation")]
-        public double DefaultUserAllocation { get; set; } 
+        public long DefaultUserAllocation { get; set; } 
     }
 }

--- a/ProvisioningLibrary/VolatileStorage/IVolatileStorageController.cs
+++ b/ProvisioningLibrary/VolatileStorage/IVolatileStorageController.cs
@@ -22,5 +22,6 @@ namespace ProvisioningLibrary
         Task<List<UserBudgetState>> GetUserBudgetStates(string userId);
         Task<UserBudgetState> GetUserBudgetState(string userId, string groupId);
         Task AddUserBudgetState(UserBudgetState budget);
+        Task AddGroupBudgetState(GroupBudgetState budget);
     }
 }

--- a/ProvisioningLibrary/VolatileStorage/VolatileStorageController.cs
+++ b/ProvisioningLibrary/VolatileStorage/VolatileStorageController.cs
@@ -221,5 +221,12 @@ namespace ProvisioningLibrary
             return;
         }
 
+        public async Task AddGroupBudgetState(GroupBudgetState budget)
+        {
+            TableOperation operation = TableOperation.InsertOrReplace(budget);
+            TableResult retrievedResult = await _StateUpdateTable.ExecuteAsync(operation);
+            return;
+        }
+
     }
 }

--- a/ScampTypes/ViewModels.cs
+++ b/ScampTypes/ViewModels.cs
@@ -40,9 +40,9 @@ namespace ScampTypes.ViewModels
 
     public sealed class GroupManagerSummary : UserSummary
     {
-        public double unitsBudgeted { get; set; }
-        public double totUnitsUsed { get; set; }
-        public double totUnitsAllocated { get; set; }
+        public long unitsBudgeted { get; set; }
+        public long totUnitsUsed { get; set; }
+        public long totUnitsAllocated { get; set; }
         public int totGroups { get; set; }
         public DateTime endDate { get; set; }
     }
@@ -136,8 +136,8 @@ namespace ScampTypes.ViewModels
     public List<ScampResourceSummary> Resources{ get; set; }
     public List<GroupTemplateSummary> Templates { get; set; }
     public List<UserSummary> Users { get; set; }
-    public double unitsBudgeted { get; set; }
-    public double defaultUserBudget { get; set; }
+    public long unitsBudgeted { get; set; }
+    public long defaultUserBudget { get; set; }
     public DateTime expiryDate { get; set; }
 
     }


### PR DESCRIPTION
complete implementation of 'create group' functionality for item #75. May still need work on return result.

Also standardizes on "long" for storing of consumption units (some areas used doubles). This will require that the current seed data is updated properly (after this PR is accepted, volatile storage entries needs to be update)