### PR TITLE
Fix group update REST endpoint

### DIFF
--- a/DocumentDbRepositories/Implementation/GroupRepository.cs
+++ b/DocumentDbRepositories/Implementation/GroupRepository.cs
@@ -30,40 +30,15 @@ namespace DocumentDbRepositories.Implementation
             return await query.AsDocumentQuery().FirstOrDefaultAsync();
         }
 
-        public async Task<ScampResourceGroupWithResources> GetGroupWithResources(string groupID)
+        public async Task<List<ScampResourceGroup>> GetGroupsByBudgetOwner(string userId)
         {
             if (!(await docdb.IsInitialized))
                 return null;
 
-            var groupQuery = from g in docdb.Client.CreateDocumentQuery<ScampResourceGroupWithResources>(docdb.Collection.SelfLink)
-                             where g.Id == groupID && g.Type == "group"
-                             select g;
-            var groupTask = groupQuery.AsDocumentQuery().FirstOrDefaultAsync();
-
-            var resourcesQuery = from r in docdb.Client.CreateDocumentQuery<ScampResource>(docdb.Collection.SelfLink)
-                                 where r.Type == "resource" && r.ResourceGroup.Id == groupID
-                                 select r;
-            var resourcesTask = resourcesQuery.AsDocumentQuery().ToListAsync();
-
-            await Task.WhenAll(groupTask, resourcesTask);
-
-            var group = groupTask.Result;
-            if (group == null)
-                return null;
-
-            //group.Resources = resourcesTask.Result;
-            return group;
-        }
-
-        public async Task<List<ScampResourceGroupWithResources>> GetGroupsByBudgetOwner(string userId)
-        {
-            if (!(await docdb.IsInitialized))
-                return null;
-
-            var groupQuery = from g in docdb.Client.CreateDocumentQuery<ScampResourceGroupWithResources>(docdb.Collection.SelfLink)
+            var groupQuery = from g in docdb.Client.CreateDocumentQuery<ScampResourceGroup>(docdb.Collection.SelfLink)
                              where g.Budget.OwnerId == userId && g.Type == "group"
                              select g;
-            List<ScampResourceGroupWithResources> groupList = await groupQuery.AsDocumentQuery().ToListAsync();
+            List<ScampResourceGroup> groupList = await groupQuery.AsDocumentQuery().ToListAsync();
 
             return groupList;
         }

--- a/DocumentDbRepositories/Interfaces.cs
+++ b/DocumentDbRepositories/Interfaces.cs
@@ -14,8 +14,7 @@ namespace DocumentDbRepositories
     public interface IGroupRepository
     {
         Task<ScampResourceGroup> GetGroup(string groupID);
-        Task<ScampResourceGroupWithResources> GetGroupWithResources(string groupID);
-        Task<List<ScampResourceGroupWithResources>> GetGroupsByBudgetOwner(string userId);
+        Task<List<ScampResourceGroup>> GetGroupsByBudgetOwner(string userId);
         Task<IEnumerable<ScampResourceGroup>> GetGroups();
         Task<IEnumerable<ScampResourceGroup>> GetGroupsByUser(ScampUserReference user);
         Task CreateGroup(ScampResourceGroup newGroup);

--- a/DocumentDbRepositories/ScampResourceGroup.cs
+++ b/DocumentDbRepositories/ScampResourceGroup.cs
@@ -27,25 +27,4 @@ namespace DocumentDbRepositories
         public string Type { get { return "group"; } }
 
     }
-
-    /// <summary>
-    /// This includes resources for the group and is used for querying.
-    /// </summary>
-    public class ScampResourceGroupWithResources
-    {
-        [JsonProperty(PropertyName = "id")]
-        public string Id { get; set; }
-        [JsonProperty(PropertyName = "name")]
-        public string Name { get; set; }
-        [JsonProperty(PropertyName = "description")]
-        public string Description { get; set; }
-        [JsonProperty(PropertyName = "members")]
-        public List<ScampUserGroupMbrship> Members { get; set; }
-        [JsonProperty(PropertyName = "budget")]
-        public ScampGroupBudget Budget { get; set; }
-
-        [JsonProperty(PropertyName = "type")]
-        public string Type { get { return "group"; } }
-
-    }
 }

--- a/ProvisioningLibrary/ResourceController.cs
+++ b/ProvisioningLibrary/ResourceController.cs
@@ -51,7 +51,7 @@ namespace ProvisioningLibrary
 
         public async Task<string> GetCloudServiceName(ScampResource scampResource)
         {
-            var grp = await _groupRepository.GetGroupWithResources(scampResource.ResourceGroup.Id);
+            var grp = await _groupRepository.GetGroup(scampResource.ResourceGroup.Id);
             return grp.Name.ToLower();
         }
 

--- a/ScampApi/Controllers/GroupsUsersController.cs
+++ b/ScampApi/Controllers/GroupsUsersController.cs
@@ -42,7 +42,7 @@ namespace ScampApi.Controllers
             //}
 
             // get group details
-            var group = await _groupRepository.GetGroupWithResources(groupId);
+            var group = await _groupRepository.GetGroup(groupId);
             if (group == null)
             {
                 return HttpNotFound();

--- a/ScampApi/Infrastructure/ISecurityHelper.cs
+++ b/ScampApi/Infrastructure/ISecurityHelper.cs
@@ -11,7 +11,7 @@ namespace ScampApi.Infrastructure
         Task<ScampUserReference> GetUserReference();
         Task<bool> IsGroupManager(string groupId);
         Task<bool> IsGroupAdmin(string groupId);
-        Task<bool> IsGroupAdmin();
+        Task<bool> IsGroupManager();
         Task<bool> IsSysAdmin();
     }
 }

--- a/ScampApi/Infrastructure/SecurityHelper.cs
+++ b/ScampApi/Infrastructure/SecurityHelper.cs
@@ -81,11 +81,11 @@ namespace ScampApi.Infrastructure
         }
 
         /// <summary>
-        /// checks to see if the user is a group manager
+        /// checks to see if the user is a group admin
         /// </summary>
         /// <param name="groupId">Id of group to be checked</param>
         /// <returns>true is the user is</returns>
-        public async Task<bool> IsGroupManager(string groupId)
+        public async Task<bool> IsGroupAdmin(string groupId)
         {
             var user = await GetCurrentUser();
             var grp = await _groupRepository.GetGroup(groupId);
@@ -95,11 +95,11 @@ namespace ScampApi.Infrastructure
         }
 
         /// <summary>
-        /// checks to see if the user is a group admin of a specific group
+        /// checks to see if the user is a group manager of a specific group
         /// </summary>
         /// <param name="groupId">Id of group to be checked</param>
         /// <returns>true is the user is</returns>
-        public async Task<bool> IsGroupAdmin(string groupId)
+        public async Task<bool> IsGroupManager(string groupId)
         {
             var user = await GetCurrentUser();
             var grp = await _groupRepository.GetGroup(groupId);
@@ -109,10 +109,10 @@ namespace ScampApi.Infrastructure
         }
 
         /// <summary>
-        /// checks to see if the user is a group admin
+        /// checks to see if the user is a group manager
         /// </summary>
         /// <returns>true is the user is</returns>
-        public async Task<bool> IsGroupAdmin()
+        public async Task<bool> IsGroupManager()
         {
             var user = await GetCurrentUser();
             // user is a group admin if they have a budget

--- a/ScampTypes/ViewModels.cs
+++ b/ScampTypes/ViewModels.cs
@@ -82,15 +82,15 @@ namespace ScampTypes.ViewModels
 
     public class ScampAdminGroupReference : ScampResourceGroupReference
     {
-        public double totUnitsUsed { get; set; }
-        public double totUnitsAllocated { get; set; }
-        public double totUnitsBudgeted { get; set; }
+        public long totUnitsUsed { get; set; }
+        public long totUnitsAllocated { get; set; }
+        public long totUnitsBudgeted { get; set; }
     }
 
     public class ScampUserGroupReference : ScampResourceGroupReference
     {
-        public double totUnitsUsedByUser { get; set; }
-        public double totUnitsRemainingForUser { get; set; }
+        public long totUnitsUsedByUser { get; set; }
+        public long totUnitsRemainingForUser { get; set; }
     }
 
     public sealed class ScampResourceSummary


### PR DESCRIPTION
- Fix group update REST endpoint
- Remove name validation on group PUT and POST requests (closes #217)
- Clean out unneeded class ScampResourceGroupWithResources, closing #225
- Rename SecurityHelper.IsGroup{Admin,Manager} to be consistent with semantics