### PR TITLE
Use Angular-based Typeahead for searching users.

### DIFF
--- a/ScampApi/wwwroot/App/Scripts/app.js
+++ b/ScampApi/wwwroot/App/Scripts/app.js
@@ -1,5 +1,5 @@
 ﻿'use strict';
-angular.module('scamp', ['ngRoute', 'AdalAngular', 'ui.bootstrap', 'ui.bootstrap.datepicker'])
+angular.module('scamp', ['ngRoute', 'AdalAngular', 'ui.bootstrap', 'ui.bootstrap.datepicker', 'ui.bootstrap.typeahead'])
 .config(['$routeProvider', '$httpProvider', 'adalAuthenticationServiceProvider', '$locationProvider', function ($routeProvider, $httpProvider, adalProvider, $locationProvider) {
 
     $routeProvider.when("/Home", {

--- a/ScampApi/wwwroot/App/Scripts/groupManagerCtrl.js
+++ b/ScampApi/wwwroot/App/Scripts/groupManagerCtrl.js
@@ -131,35 +131,27 @@ angular.module('scamp')
         $('.filtered-data tr').show();
     };
 
-    // Setup the typeahead logic for adding new users
-    // to the group.
     $scope.addUser = {};
-    $scope.addUser.start = function () {
-        $scope.addUser.started = true;
+    $scope.addUser.searchUsers = function (keyword) {
+        return userSvc.searchUsers(keyword)
+        .then(function (response) {
+            return response;
+        });
     };
-    new Typeahead($scope,
-        {
-            componentId: 'add-user-typeahead',
-            minLength: 3,
-            remote: {
-                url: '/api/users/FindbyUPN/%QUERY',
-                queryStr: '%QUERY',
-                displayProperty: 'name'
-            }
-        },
-        function (event, value) {
-            $scope.addUser.loading = true;
-            groupsSvc.addUser($scope.selectedGroup, value)
-            .then(function () {
-                $scope.selectedGroup.users.unshift(value);
-            })
-            .finally(function () {
-                $scope.addUser.started = false;
-                $scope.addUser.loading = false;
-                $('#add-user-typeahead .typeahead').typeahead('val', '');
-            });
-        }
-    );
+    $scope.addUser.userSelected = function ($item, $model, $label) {
+        $scope.addUser.selectedUser = $item;
+    };
+    $scope.addUser.add = function () {
+        $scope.addUser.loading = true;
+        groupsSvc.addUser($scope.selectedGroup, $scope.addUser.selectedUser)
+        .then(function (response) {
+            $scope.selectedGroup.users.unshift(response);
+        })
+        .finally(function () {
+            $scope.addUser.selectedUserName = '';
+            $scope.addUser.loading = false;
+        });
+    };
 
     $scope.removeUser = function (user) {
         user.removing = true;

--- a/ScampApi/wwwroot/App/Services/userSvc.js
+++ b/ScampApi/wwwroot/App/Services/userSvc.js
@@ -16,6 +16,11 @@ angular.module('scamp')
             var restCall = '/api/users/' + userId + '/groups/' + view;
 
             return scamp.utils.restAjaxPromise($http, $q, 'GET', restCall);
+        },
+
+        searchUsers: function (keyword) {
+            var url = '/api/users/FindbyUPN/' + keyword;
+            return scamp.utils.restAjaxPromise($http, $q, 'GET', url);
         }
-  };
+    };
 }]);

--- a/ScampApi/wwwroot/App/Views/GroupManager.html
+++ b/ScampApi/wwwroot/App/Views/GroupManager.html
@@ -143,17 +143,22 @@
                     </span>
                   </div>
                 </div>
-                <div class="col-sm-offset-2 col-sm-6">
-                  <button type="button" class="btn btn-default btn-md pull-right"
-                    ng-click="addUser.start()"
-                    ng-show="!addUser.started && !addUser.loading">
-                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
-                    Add User
-                  </button>
-                  <div id="add-user-typeahead" class="pull-right"
-                    ng-show="addUser.started && !addUser.loading">
-                    <input type="text" class="typeahead"
-                      placeholder="Search user...">
+                <div class="col-sm-offset-3 col-sm-1">
+                  <i class="fa fa-spinner fa-pulse fa-2x pull-right" ng-show="addUser.searchingUsers"></i>
+                </div>
+                <div class="col-sm-4">
+                  <div class="input-group" ng-show="!addUser.loading">
+                    <input type="text" ng-model="addUser.selectedUserName"
+                      placeholder="Add users..." typeahead="foundUser.name for foundUser in addUser.searchUsers($viewValue)"
+                      typeahead-loading="addUser.searchingUsers" typeahead-editable="false"
+                      typeahead-on-select="addUser.userSelected($item, $model, $label)"
+                      class="form-control">
+                    <span class="input-group-btn">
+                      <button class="btn btn-default" type="button"
+                        ng-click="addUser.add()">
+                        Add
+                      </button>
+                    </span>
                   </div>
                   <i class="fa fa-spinner fa-pulse fa-2x pull-right" ng-show="addUser.loading"></i>
                 </div>


### PR DESCRIPTION
This addresses #227 by fixing a problem where authentication wasn't working
with requests done from the Typeahead component.

Our authentication headers are currently added automatically by ADAL, but
the previously used Typeahead component was doing the HTTP requests outside
of Angular (using jQuery directly) so headers weren't added.