### PR TITLE
Fix for issue/task #253 (add new flags for isGroupManager and isGroupAdmin

### DIFF
--- a/DocDbSetup/SP_CreateGroup.js
+++ b/DocDbSetup/SP_CreateGroup.js
@@ -45,7 +45,8 @@ function (groupDoc) {
         // define group for group list
         var userFrag = {
             "id": groupDoc.id,
-            "name": groupDoc.name
+            "name": groupDoc.name,
+            "isManager" : "true"
         };
         // add the group to the user membership collection
         userDoc.groupmbrship.push(userFrag);

--- a/DocumentDbRepositories/ScampUser.cs
+++ b/DocumentDbRepositories/ScampUser.cs
@@ -15,7 +15,6 @@ namespace DocumentDbRepositories
         public ScampUser()
         {
             GroupMembership = new List<ScampUserGroupMbrship>();
-            budget = new ScampUserBudget();
         }
 
         [JsonProperty(PropertyName = "name")]
@@ -33,7 +32,7 @@ namespace DocumentDbRepositories
         [JsonProperty(PropertyName = "groupmbrship")]
         public List<ScampUserGroupMbrship> GroupMembership { get; set; }
 
-        [JsonProperty(PropertyName = "budget")]
+        [JsonProperty(PropertyName = "budget", NullValueHandling = NullValueHandling.Ignore)]
         public ScampUserBudget budget { get; set; }
     }
 

--- a/ScampApi/Controllers/GroupsUsersController.cs
+++ b/ScampApi/Controllers/GroupsUsersController.cs
@@ -102,6 +102,9 @@ namespace ScampApi.Controllers
             if (userList.Count() > 0) // user is already in the list
                 return new ObjectResult("designated user is already a member of specified group") { StatusCode = 400 };
 
+            // create the user if they don't exist
+            //TODO: https://github.com/SimpleCloudManagerProject/SCAMP/issues/247
+
             //TODO: Issue #152
             // check to make sure enough remains in the group allocation to allow add of user
 

--- a/ScampApi/Controllers/UserController.cs
+++ b/ScampApi/Controllers/UserController.cs
@@ -28,8 +28,11 @@ namespace ScampApi.Controllers
       _graphAPIProvider = graphAPIProvider;
     }
 
-    // retrieves the current user
-    // GET: api/user
+    /// <summary>
+    /// retrieves current user
+    /// GET: api/user
+    /// </summary>
+    /// <returns></returns>
     [HttpGet(Name = "User.CurrentUser")]
     public async Task<User> Get()
     {
@@ -46,7 +49,9 @@ namespace ScampApi.Controllers
         Id = tmpUser.Id,
         Name = tmpUser.Name,
         Email = tmpUser.Email,
-        IsSystemAdmin = tmpUser.IsSystemAdmin
+        isSystemAdmin = await _securityHelper.IsSysAdmin(),
+        isGroupAdmin = await _securityHelper.IsGroupAdmin(),
+        isGroupManager = await _securityHelper.IsGroupManager()
       };
 
       return user;

--- a/ScampApi/Infrastructure/ISecurityHelper.cs
+++ b/ScampApi/Infrastructure/ISecurityHelper.cs
@@ -9,6 +9,7 @@ namespace ScampApi.Infrastructure
         Task<ScampUser> GetCurrentUser();
         Task<ScampUser> GetUserById(string IPID);
         Task<ScampUserReference> GetUserReference();
+        Task<bool> IsGroupManager();
         Task<bool> IsGroupManager(string groupId);
         Task<bool> IsGroupAdmin(string groupId);
         Task<bool> IsGroupAdmin();

--- a/ScampApi/Infrastructure/SecurityHelper.cs
+++ b/ScampApi/Infrastructure/SecurityHelper.cs
@@ -81,10 +81,22 @@ namespace ScampApi.Infrastructure
         }
 
         /// <summary>
+        /// checks to see if the user is a group manager of any group they are a member of
+        /// </summary>
+         /// <returns>true if the user is</returns>
+        public async Task<bool> IsGroupManager()
+        {
+            var user = await GetCurrentUser();
+            // user is a manager of this group if they are in the group membership list and are flagged "isManager"
+            var checkMgr = user.GroupMembership.ToList().Any(q => q.isManager);
+            return checkMgr;
+        }
+
+        /// <summary>
         /// checks to see if the user is a group manager
         /// </summary>
         /// <param name="groupId">Id of group to be checked</param>
-        /// <returns>true is the user is</returns>
+        /// <returns>true if the user is</returns>
         public async Task<bool> IsGroupManager(string groupId)
         {
             var user = await GetCurrentUser();
@@ -115,8 +127,8 @@ namespace ScampApi.Infrastructure
         public async Task<bool> IsGroupAdmin()
         {
             var user = await GetCurrentUser();
-            // user is a group admin if they have a budget
-            var checkMgr = user.budget != null; 
+            // user is a group admin if they have a budget > 0
+            var checkMgr = user.budget != null && user.budget.unitsBudgeted > 0; 
             return checkMgr;
         }
 

--- a/ScampTypes/ViewModels.cs
+++ b/ScampTypes/ViewModels.cs
@@ -106,7 +106,9 @@ namespace ScampTypes.ViewModels
         public string Email { get; set; }
         public List<Group> Groups { get; set; }
         public ScampResourceSummary Resources { get; set; }
-        public bool IsSystemAdmin { get; set; }
+        public bool isSystemAdmin { get; set; }
+        public bool isGroupAdmin { get; set; }
+        public bool isGroupManager { get; set; }
     }
 
     public sealed class GroupTemplate


### PR DESCRIPTION
fixes #253 by adding two new flags to the $scope.userprofile object returned by api/user. Also fixes a previously unreported issue with the 'creategroup' stored procedure whereby the user was not flagged as a manager of a group they just created in the user document

![proof](https://cloud.githubusercontent.com/assets/1760519/8367557/6c4035ea-1b6d-11e5-8bea-abd2b8b49ebd.png)