### PR TITLE
fixes #262

### DIFF
--- a/DocDbSetup/SP_AddUserToGroup.js
+++ b/DocDbSetup/SP_AddUserToGroup.js
@@ -49,7 +49,7 @@ function (groupId, userId) {
         if (typeof(groupDoc.members) == 'undefined' || groupDoc.members == null)
             groupDoc.member = [];
         groupDoc.members.push(userFrag);
-        if (typeof(userDoc.members) == 'undefined' || userDoc.members == null)
+        if (typeof(userDoc.groupmbrship) == 'undefined' || userDoc.groupmbrship == null)
             userDoc.groupmbrship = [];
         userDoc.groupmbrship.push(groupFrag);
 


### PR DESCRIPTION
fixes #262 by correcting the stored procedure to only initialize the user document's groupmbrship when its really needed. Error was due to a copy/paste issue that referenced a non-existence property and thus caused the user doc membership collection to always be cleared out