### PR TITLE
Fix the Microsoft.AspNet.Mvc dependency.

### DIFF
--- a/ScampApi/project.json
+++ b/ScampApi/project.json
@@ -10,7 +10,7 @@
     "dependencies": {
     "Microsoft.AspNet.Server.IIS": "1.0.0-beta4",
     "Microsoft.AspNet.Server.WebListener": "1.0.0-beta4",
-    "Microsoft.AspNet.Mvc": "6.0.0-*",
+    "Microsoft.AspNet.Mvc": "6.0.0-beta4",
     "Microsoft.AspNet.StaticFiles": "1.0.0-beta4",
     "Microsoft.Framework.ConfigurationModel.Json": "1.0.0-beta4",
     "Microsoft.Framework.DependencyInjection": "1.0.0-beta4",


### PR DESCRIPTION
This fixes a build error that started occurring yesterday after the beta5
package was published in nuget.